### PR TITLE
Fixed to make load the GET stripe required api.

### DIFF
--- a/static/templates/subscribe.tpl
+++ b/static/templates/subscribe.tpl
@@ -29,8 +29,8 @@
 
                         <button id="customButton" class="btn btn-primary btn-block">Join Now!</button>
 
-                        <script>
-                        window.onload = function(){    
+                        <script type='text/javascript'>
+                        $(document).ready(function(){   
                             var handler = StripeCheckout.configure({
                               key: '{publish_key}',
                               image: 'https://stripe.com/img/documentation/checkout/marketplace.png',


### PR DESCRIPTION
Otherwise if you visit the menu, it will not propagate the api connection info unless you manually reload the page.